### PR TITLE
Fix missing type conversion for HTTP port and scrape interval

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -221,14 +221,14 @@ if __name__ == '__main__':
     logging.info("Reading environment configuration")
 
     # Read the configuration
-    http_port = os.getenv('HTTP_PORT', 9351)
+    http_port = int(os.getenv('HTTP_PORT', 9351))
     pg_host = os.getenv('PGHOST', 'localhost')
     pg_port = os.getenv('PGPORT', '5432')
     pg_user = os.getenv('PGUSER', 'postgres')
     pg_database = os.getenv('PGDATABASE', 'postgres')
     pg_password = os.getenv('PGPASSWORD')
     pg_ssl_mode = os.getenv('PGSSLMODE', 'require')
-    wal_g_scrape_interval = os.getenv('WAL_G_SCRAPE_INTERVAL', 60)
+    wal_g_scrape_interval = int(os.getenv('WAL_G_SCRAPE_INTERVAL', 60))
     first_start = True
 
     # Start up the server to expose the metrics.


### PR DESCRIPTION
If you set the `HTTP_PORT` environment variable, the exporter crashes on startup:

```
2023-08-09 11:52:15,691 - Reading environment configuration
Traceback (most recent call last):
  File "exporter.py", line 235, in <module>
  File "prometheus_client/exposition.py", line 171, in start_wsgi_server
  File "wsgiref/simple_server.py", line 154, in make_server
  File "socketserver.py", line 452, in __init__
  File "wsgiref/simple_server.py", line 50, in server_bind
  File "http/server.py", line 137, in server_bind
  File "socketserver.py", line 466, in server_bind
TypeError: an integer is required (got type str)
```

This is because `os.getenv` always returns a `str`, but it is used in contexts where an `int` is required. This MR fixes this issue and a similar issue with the environment variable `WAL_G_SCRAPE_INTERVAL`.