### PR TITLE
fix(entrypoint): add retry

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
-sleep 5
+for run in {1..30}; do
+  echo "waiting /run/etc/wal-e.d/env to come up... retry $run"
+  ls /run/etc/wal-e.d/env
+  if find /run/etc/wal-e.d/env -mindepth 1 -maxdepth 1 | read; then
+    echo "/run/etc/wal-e.d/env is populated, starting now..."
+    break
+  fi
+  sleep 6
+done
 exec envdir /run/etc/wal-e.d/env wal-g-prometheus-exporter


### PR DESCRIPTION
In my test, the spilo container was slow to come up, and I didn't want to have a restart of this container.

So here is the retry loop!

fixes #15